### PR TITLE
Update platformio.ini

### DIFF
--- a/automatic_cubemx/platformio.ini
+++ b/automatic_cubemx/platformio.ini
@@ -28,6 +28,7 @@ platform = ststm32
 board = <board_definition>
 ; This value will be removed by the script but is needed to satisfy the
 ; build implementation. The actual framework name does not matter.
+; rectify：The next line is unnecessary and would download extra resources that are not needed.
 framework = stm32cube
 ; This is the actual script that forces platformio into compiling the
 ; STM32CubeIDE project.


### PR DESCRIPTION
I found that when setting up a platform, every time the platformio.ini file is updated, it causes the pio to search for the resources needed by the platform and download them, which are not needed (cubemx has already generated the required resources).