### PR TITLE
Update linker script search for versions of STM32CubeIDE that use "MCU/MPU GCC Linker"

### DIFF
--- a/automatic_cubemx/setup_cubemx_env_auto.py
+++ b/automatic_cubemx/setup_cubemx_env_auto.py
@@ -285,6 +285,9 @@ ld_script_entry = tool_chain.find("tool[@name='MCU GCC Linker']/option")
 if ld_script_entry == None:
     # The G++ linker entries
     ld_script_entry = tool_chain.find("tool[@name='MCU G++ Linker']/option")
+    if ld_script_entry == None:
+        # Some versions of STM32CubeIDE use "MCU/MPU GCC Linker"
+        ld_script_entry = tool_chain.find("tool[@name='MCU/MPU GCC Linker']/option")
 
 ld_script = None
 if ld_script_entry != None:


### PR DESCRIPTION
On my version of STM32CubeIDE (1.16.0), the linker options are under the name "MCU/MPU GCC Linker". This causes setup_cubemx_env_auto.py to fail to find the linker script. I have modified setup_cubemx_env_auto.py to also look for that name.

For search engines: if you're using this repo and getting "Warn : no flash bank found for address" when trying to upload in platform.io, it might be because setup_cubemx_env_auto.py couldn't find the linker script, then used a default platform.io linker script and probably put all the sections in incorrect addresses.